### PR TITLE
Add GitHub Skills activity (#6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This pull request adds the GitHub Skills activity that was announced by the principal in the school assembly.

## Resolves
Closes #6

## Changes
- Added GitHub Skills activity to the activities list
- Activity includes GitHub Certifications program information
- Set capacity to 25 participants to accommodate high student interest
- Activity starts Mondays at 3:30 PM

## Testing
The activity is now visible in the web interface and students can register for it just like other activities.

## Notes
This resolves the time-sensitive issue where students could not register for the GitHub Skills activity that was announced to help with college applications.